### PR TITLE
fix build errors due to dependency problems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update -qq && \
                 libcairo2-dev/unstable \
                 libcurl4-openssl-dev/unstable \
                 libfreetype6-dev/unstable \
-    		libharfbuzz-dev/unstable \
+                libharfbuzz-dev/unstable \
                 libjpeg-dev \
                 liblapack-dev \
                 liblzma-dev \
@@ -92,14 +92,14 @@ RUN apt-get update -qq && \
         && mv Rscript Rscriptdevel \
         && ln -s Rdevel RD \
         && ln -s Rscriptdevel RDscript \
-        && dpkg --purge  \
+        && apt-get purge -qy \
                 libblas-dev \
                 libbz2-dev  \
                 libcairo2-dev \
                 libfontconfig1-dev \
                 libfreetype6-dev \
                 libglib2.0-dev \
-    		libharfbuzz-dev \
+                libharfbuzz-dev \
                 libjpeg-dev \
                 liblapack-dev  \
                 liblzma-dev \
@@ -119,4 +119,4 @@ RUN apt-get update -qq && \
                 texlive-latex-recommended \
                 tk8.6-dev \
         && apt-get autoremove -qy
-        
+


### PR DESCRIPTION
use `apt-get purge` instead of `dpkg --purge` for cleanup to ensure dependencies are dealt with.

fixes recent build errors (e.g. #6)

successfully rebuilt image on my Ubuntu 16.04 machine:

```
$ docker run -it --rm rocker/drd RD

R Under development (unstable) (2017-08-29 r73153) -- "Unsuffered Consequences"
Copyright (C) 2017 The R Foundation for Statistical Computing
Platform: x86_64-pc-linux-gnu (64-bit)

R is free software and comes with ABSOLUTELY NO WARRANTY.
You are welcome to redistribute it under certain conditions.
Type 'license()' or 'licence()' for distribution details.

  Natural language support but running in an English locale

R is a collaborative project with many contributors.
Type 'contributors()' for more information and
'citation()' on how to cite R or R packages in publications.

Type 'demo()' for some demos, 'help()' for on-line help, or
'help.start()' for an HTML browser interface to help.
Type 'q()' to quit R.

> 
```